### PR TITLE
Numpy 1.18 build fixes

### DIFF
--- a/src/utils/nfft/nfftmodule.c
+++ b/src/utils/nfft/nfftmodule.c
@@ -1,5 +1,6 @@
 #include <Python.h>
 #include "structmember.h"
+#include <numpy/npy_common.h>
 #include <numpy/arrayobject.h>
 #include <nfft3.h>
 #include <math.h>
@@ -88,8 +89,8 @@ static PyObject *nfft(PyObject *self, PyObject *args, PyObject *kwargs)
 
   nfft_trafo(&my_plan);
 
-  int out_dim[] = {number_of_points};
-  PyObject *out_array = (PyObject *)PyArray_FromDims(1, out_dim, NPY_COMPLEX128);
+  npy_intp out_dim[] = {number_of_points};
+  PyObject *out_array = (PyObject *)PyArray_SimpleNew(1, out_dim, NPY_COMPLEX128);
   memcpy(PyArray_DATA(out_array), my_plan.f, number_of_points*sizeof(fftw_complex));
 
   // Clean up memory


### PR DESCRIPTION
Hello, 

the PR fixes a segmentation fault with Numpy 1.18+ builds.

The reason is the following: `PyArray_FromDims()` was [removed](https://numpy.org/devdocs/release/1.18.0-notes.html) from the Numpy API. Actually, it wasn't removed, but it always returns an error.

The first commit d8c103e876f8946c823e4831c3bd4419fcc5516e contains the actual fix. It replaces `PyArray_FromDims()` by `PyArray_SimpleNew()`. The second commit a8393addf29b7dfdbaa705729c2e71346080170e adds various extra checks in order to improve error handling.

`PyArray_SimpleNew()` is available even in ancient Numpy releases (e.g. [Numpy 1.3](https://docs.scipy.org/doc/numpy-1.3.x/reference/c-api.array.html#PyArray_SimpleNew)). Therefore there's no need to check the Numpy version and handle different cases.