### PR TITLE
Update resample.py

### DIFF
--- a/condor/utils/resample.py
+++ b/condor/utils/resample.py
@@ -89,8 +89,8 @@ def downsample(array2d0,factor0,mode="pick",mask2d0=None,bad_bits=None,min_N_pix
         Y,X = numpy.indices((Ny,Nx))
         Y = Y.flatten()
         X = X.flatten()
-        Y /= factor
-        X /= factor
+        Y //= factor
+        X //= factor
         superp = Y*Nx_new+X
         superp_order = superp.argsort()
         A = A[superp_order]


### PR DESCRIPTION

Fixed pixel binning factor calculation.
Line 92 to Line 93:
TypeError: No loop matching the specified signature and casting was found for ufunc true_divide
The problem is that we can't divided using /= on an Numpy-array.
The proposed fix is to replace the division by //=:
Y //= factor
X //= factor